### PR TITLE
Update fetch_libs.sh for Windows

### DIFF
--- a/fetch_libs.sh
+++ b/fetch_libs.sh
@@ -2,7 +2,7 @@ ARM_DOWNLOAD="https://download.01.org/crosswalk/releases/crosswalk/android/canar
 X86_DOWNLOAD="https://download.01.org/crosswalk/releases/crosswalk/android/canary/8.37.189.0/x86/crosswalk-webview-8.37.189.0-x86.zip";
 
 download() {
-    TMPDIR=$(mktemp -d xwdl.XXXXXX)
+    TMPDIR=cordova-crosswalk-engine-$$
     pushd $TMPDIR > /dev/null
     echo "Fetching $1..."
     curl -# $1 -o library.zip


### PR DESCRIPTION
Bash provided through git-bash doesn't have an mktemp command.
