### PR TITLE
Add a varibale of library mode when installing plugin

### DIFF
--- a/hooks/after_plugin_install/000-apply_cli_options.js
+++ b/hooks/after_plugin_install/000-apply_cli_options.js
@@ -35,12 +35,15 @@ module.exports = function(context) {
         XmlHelpers = context.requireCordovaModule("cordova-lib/src/util/xml-helpers"),
         CordovaCli = path.dirname(path.dirname(process.mainModule.filename)),
         nopt = require(path.join(CordovaCli, 'node_modules', 'nopt')),
-        _ = require(path.join(CordovaCli, 'node_modules', 'underscore'));
+        _ = require(path.join(CordovaCli, 'node_modules', 'underscore')),
+        et = context.requireCordovaModule('elementtree');
 
     /** @defaults */
     var argumentsString = context.cmdLine,
         pluginConfigurationFile = path.join(context.opts.plugin.dir, 'plugin.xml'),
-        projectConfigurationFile = path.join(context.opts.projectRoot, 'config.xml');
+        projectConfigurationFile = path.join(context.opts.projectRoot, 'config.xml'),
+        projectManifestFile = path.join(context.opts.projectRoot,
+            "platforms", "android", 'AndroidManifest.xml');
 
     /** Init */
     var CordovaConfig = new ConfigParser(projectConfigurationFile);
@@ -93,6 +96,14 @@ module.exports = function(context) {
         return commandlineVariables;
     };
 
+    var addPermission = function() {
+        if (_.property('LIB_MODE')(cliPreferences()) == 'shared') {
+            var projectManifestXmlRoot = XmlHelpers.parseElementtreeSync(projectManifestFile);
+            var child = et.XML('<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />');
+            XmlHelpers.graftXML(projectManifestXmlRoot, [child], '/manifest');
+            fs.writeFileSync(projectManifestFile, projectManifestXmlRoot.write({indent: 4}), 'utf-8');
+        }
+    }
 
     /** Main method */
     // Set default values for any undefined properties
@@ -119,6 +130,9 @@ module.exports = function(context) {
 
         // Write config.xml
         CordovaConfig.write();
+
+        // Add the permission of write_external_storage in shared mode
+        addPermission();
 
         deferral.resolve();
     };

--- a/platforms/android/xwalk.gradle
+++ b/platforms/android/xwalk.gradle
@@ -17,8 +17,11 @@
        under the License.
 */
 
-def DEFAULT_VERSION = "org.xwalk:xwalk_core_library_beta:13+"
-def DEFAULT_COMMANDLINE = "--disable-pull-to-refresh-effect"
+def EMBEDDED_MODE = "embedded"
+def SHARED_MODE = "shared"
+def DEFAULT_GROUP_ID = "org.xwalk:"
+def SHARED_ARTIFACT_ID = "xwalk_shared_library_beta:"
+def EMBEDD_ARTIFACT_ID = "xwalk_core_library_beta:"
 
 repositories {
   maven {
@@ -33,42 +36,51 @@ if (cdvMinSdkVersion == null) {
     ext.cdvMinSdkVersion = 14
 }
 
-def getConfigPreference(name, defaultValue) {
+def getConfigPreference(name) {
     name = name.toLowerCase()
     def xml = file("res/xml/config.xml").getText()
     // Disable namespace awareness since Cordova doesn't use them properly
     def root = new XmlParser(false, false).parseText(xml)
 
-    def ret = defaultValue
+    def ret, defaultValue
     root.preference.each { it ->
         def attrName = it.attribute("name")
         if (attrName && attrName.toLowerCase() == name) {
-            ret = it.attribute("value")
+            if (it.attribute('default') != null) {
+                defaultValue = it.attribute('default');
+            } else {
+                ret = it.attribute("value")
+            }
         }
     }
-    return ret
+    return ret ? ret : defaultValue
 }
 
+if (!project.hasProperty('lib_mode')) {
+    def mode = getConfigPreference("LIB_MODE")
+    println mode
+    ext.artifactid = mode == SHARED_MODE ? SHARED_ARTIFACT_ID : EMBEDD_ARTIFACT_ID;
+}
 // Set defaults before project's build-extras.gradle
 if (!project.hasProperty('xwalkVersion')) {
-    ext.xwalkVersion = getConfigPreference("CROSSWALK_ANDROID_VERSION", DEFAULT_VERSION)
+    ext.xwalkVersion = getConfigPreference("CROSSWALK_ANDROID_VERSION")
 }
 if (!project.hasProperty('xwalkCommandLine')) {
-    ext.xwalkCommandLine = getConfigPreference("CROSSWALK_ANDROID_COMMANDLINE", DEFAULT_COMMANDLINE)
+    ext.xwalkCommandLine = getConfigPreference("CROSSWALK_ANDROID_COMMANDLINE")
 }
-
 // Apply values after project's build-extras.gradle
 cdvPluginPostBuildExtras.add({
 
     def xwalkSpec = xwalkVersion
     if ((xwalkSpec =~ /:/).count == 1) {
-        xwalkSpec = "org.xwalk:${xwalkSpec}"
+        xwalkSpec = DEFAULT_GROUP_ID + xwalkSpec
     } else if ((xwalkSpec =~ /:/).count == 0) {
         if (xwalkSpec ==~ /\d+/) {
             xwalkSpec = "${xwalkSpec}+"
         }
-        xwalkSpec = "org.xwalk:xwalk_core_library_beta:${xwalkSpec}"
+        xwalkSpec = DEFAULT_GROUP_ID + artifactid + xwalkSpec
     }
+    println xwalkSpec
 
     dependencies {
         compile xwalkSpec

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,12 +24,14 @@
             <!-- Crosswalk Version -->
             <!-- Example: '10', '15+', 'xwalk_core_library_beta:9+', 'org.xwalk:xwalk_core_library_beta:18+' -->
             <!-- Reference: https://crosswalk-project.org/documentation/downloads.html -->
-            <preference name="CROSSWALK_ANDROID_VERSION" default="13+"/>
+            <preference name="CROSSWALK_ANDROID_VERSION" default="14+"/>
 
             <!-- Crosswalk Arguments-->
             <!-- Default: '––disable-pull-to-refresh-effect' -->
             <!-- Reference: https://github.com/crosswalk-project/crosswalk-website/wiki/Crosswalk-Command-Line-Options -->
             <preference name="CROSSWALK_ANDROID_COMMANDLINE" default="––disable-pull-to-refresh-effect"/>
+
+            <preference name="LIB_MODE" default="embedded" />
         </config-file>
 
         <source-file src="platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java" target-dir="src/org/crosswalk/engine"/>


### PR DESCRIPTION
Use the parameter of LIB_MODE to specify the usage of Crosswalk runtime library
when installing the plugin, Use shared mode like --variable LIB_MODE="shared".

Also user can specify different Crosswalk version using a <preference> tag within your config.xml
The version of 13 in embedd mode
<preference name="xwalkVersion" value="org.xwalk:xwalk_core_library_beta:13+" />
<preference name="xwalkVersion" value="xwalk_core_library_beta:13+" />
The version of 13 in shared mode
<preference name="xwalkVersion" value="org.xwalk:xwalk_shared_library_beta:13+" />
<preference name="xwalkVersion" value="xwalk_shared_library_beta:13+" />
The used mode will depend on the preference of {{lib_mode}}
<preference name="xwalkVersion" value="13+" />
<preference name="xwalkVersion" value="13" />