### PR TITLE
Fix issue of failing to launch camera when tapping input tag.

### DIFF
--- a/src/android/XWalkCordovaUiClient.java
+++ b/src/android/XWalkCordovaUiClient.java
@@ -173,21 +173,13 @@ public class XWalkCordovaUiClient extends XWalkUIClient {
     // File Chooser
     @Override
     public void openFileChooser(XWalkView view, final ValueCallback<Uri> uploadFile, String acceptType, String capture) {
-        Intent i = new Intent(Intent.ACTION_GET_CONTENT);
-        i.addCategory(Intent.CATEGORY_OPENABLE);
-        i.setType("*/*"); // TODO: wire this to acceptType.
-        Intent intent = Intent.createChooser(i, "File Browser");
-        try {
-            parentEngine.cordova.startActivityForResult(new CordovaPlugin() {
-                @Override
-                public void onActivityResult(int requestCode, int resultCode, Intent intent) {
-                    Uri result = intent == null || resultCode != Activity.RESULT_OK ? null : intent.getData();
-                    uploadFile.onReceiveValue(result);
-                }
-            }, intent, FILECHOOSER_RESULTCODE);
-        } catch (ActivityNotFoundException e) {
-            Log.w("No activity found to handle file chooser intent.", e);
-            uploadFile.onReceiveValue(null);
-        }
+        uploadFile.onReceiveValue(null);
+
+        parentEngine.cordova.setActivityResultCallback(new CordovaPlugin() {
+            @Override
+            public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+                parentEngine.webView.onActivityResult(requestCode, resultCode, intent);
+            }
+        });
     }
 }


### PR DESCRIPTION
Chromium has already implemented a better file chooser for android,
so bypass that implemented by Cordova.

Cherry pick it from Crosswalk-cordova
https://github.com/crosswalk-project/crosswalk-cordova-android/commit/ac6eb0958a3c4a3ddcb04decb7fb1ba9ac7f66f7

BUG=XWALK-4437