### PR TITLE
Permissions needed for detecting connection status

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,11 @@
             <preference name="LIB_MODE" default="embedded" />
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+            <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+        </config-file>
+
         <source-file src="platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java" target-dir="src/org/crosswalk/engine"/>
         <source-file src="platforms/android/src/org/crosswalk/engine/XWalkExposedJsApi.java" target-dir="src/org/crosswalk/engine"/>
         <source-file src="platforms/android/src/org/crosswalk/engine/XWalkCordovaResourceClient.java" target-dir="src/org/crosswalk/engine"/>


### PR DESCRIPTION
Originally added to cordova-android:
https://github.com/apache/cordova-android/commit/4a67dd2e28aed257c85b75c11026ae7a2a19c2ad

These instead should only be added for crosswalk by relegating them to
its plugin