### PR TITLE
Update repository and issue tracker information in pacakge.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MobileChromeApps/cordova-crosswalk-engine.git"
+    "url": "https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview.git"
   },
   "keywords": [
     "cordova",
@@ -34,7 +34,7 @@
   "author": "",
   "license": "Apache 2.0",
   "bugs": {
-    "url": "https://github.com/MobileChromeApps/cordova-crosswalk-engine/issues"
+    "url": "https://crosswalk-project.org/jira"
   },
-  "homepage": "https://github.com/MobileChromeApps/cordova-crosswalk-engine"
+  "homepage": "https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview"
 }


### PR DESCRIPTION
The Git links and issue tracker in package.json needed updating since the plugin source have moved to the crosswalk-project organization in Github, and Jira is used by the Crosswalk team to track issues. 