### PR TITLE
fix android namespace in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+        xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-crosswalk-webview"
         version="1.4.0-dev">
 


### PR DESCRIPTION
This change allows easy install the plugin in Visual Studio 2015 directly from github repo.