### PR TITLE
Prevent hooks failures in newest cordova versions

### DIFF
--- a/hooks/update_config.js
+++ b/hooks/update_config.js
@@ -2,11 +2,19 @@
 
 module.exports = function(context) {
 
+    var ConfigParser, XmlHelpers;
+    try {
+        ConfigParser = context.requireCordovaModule("cordova-lib/src/configparser/ConfigParser");
+        XmlHelpers = context.requireCordovaModule("cordova-lib/src/util/xml-helpers");
+    } catch (e) {
+        // cordova-lib >= 5.3.4 doesn't contain ConfigParser and xml-helpers anymore
+        ConfigParser = context.requireCordovaModule("cordova-common").ConfigParser;
+        XmlHelpers = context.requireCordovaModule("cordova-common").xmlHelpers;
+    }
+
     /** @external */
     var fs = context.requireCordovaModule('fs'),
         path = context.requireCordovaModule('path'),
-        ConfigParser = context.requireCordovaModule("cordova-lib/src/configparser/ConfigParser"),
-        XmlHelpers = context.requireCordovaModule("cordova-lib/src/util/xml-helpers"),
         et = context.requireCordovaModule('elementtree');
 
     /** @defaults */


### PR DESCRIPTION
Since 5.3.4 cordova won't contain `ConfigParser` and `xml-helpers` modules so hooks will became broken. For more details and repro steps see corresponding JIRA issue: https://issues.apache.org/jira/browse/CB-9834