### PR TITLE
fix broken plugman engine tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
 
     <engines>
         <engine name="cordova-android" version=">=4"/>
-        <engine name="cordova-plugman" version=">=4.2.0"/><!-- needed for gradleReference support -->
+        <engine name="cordova-lib" version=">=4.2.0"/><!-- needed for gradleReference support -->
     </engines>
 
     <!-- android -->


### PR DESCRIPTION
cordova-plugman version 4.2.0 doesn't exist, however cordova-lib@4.2.0
does and makes sense for the gradleReference requirement