### PR TITLE
Revert "fix broken plugman engine tag"

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
 
     <engines>
         <engine name="cordova-android" version=">=4"/>
-        <engine name="cordova-lib" version=">=4.2.0"/><!-- needed for gradleReference support -->
+        <engine name="cordova-plugman" version=">=4.2.0"/><!-- needed for gradleReference support -->
     </engines>
 
     <!-- android -->


### PR DESCRIPTION
This reverts commit a39c31ffb289d8502660dabe0c7ac74768fa78b5.

Cordova-lib is not included in the list of default engines that tag supports.
The deault engines define in default-engines.js.
Plugman will get the version of cordova-plugman from cordova-lib, so
the version of them are same.

BUG=XWALK-5633