### PR TITLE
Public the three APIs align with xwalk core library

### DIFF
--- a/platforms/android/src/org/crosswalk/engine/XWalkCordovaUiClient.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkCordovaUiClient.java
@@ -68,7 +68,7 @@ public class XWalkCordovaUiClient extends XWalkUIClient {
     /**
      * Tell the client to display a javascript alert dialog.
      */
-    private boolean onJsAlert(XWalkView view, String url, String message,
+    public boolean onJsAlert(XWalkView view, String url, String message,
                               final XWalkJavascriptResult result) {
         dialogsHelper.showAlert(message, new CordovaDialogsHelper.Result() {
             @Override
@@ -86,7 +86,7 @@ public class XWalkCordovaUiClient extends XWalkUIClient {
     /**
      * Tell the client to display a confirm dialog to the user.
      */
-    private boolean onJsConfirm(XWalkView view, String url, String message,
+    public boolean onJsConfirm(XWalkView view, String url, String message,
                                 final XWalkJavascriptResult result) {
         dialogsHelper.showConfirm(message, new CordovaDialogsHelper.Result() {
             @Override
@@ -109,7 +109,7 @@ public class XWalkCordovaUiClient extends XWalkUIClient {
      * Since we are hacking prompts for our own purposes, we should not be using them for
      * this purpose, perhaps we should hack console.log to do this instead!
      */
-    private boolean onJsPrompt(XWalkView view, String origin, String message, String defaultValue,
+    public boolean onJsPrompt(XWalkView view, String origin, String message, String defaultValue,
                                final XWalkJavascriptResult result) {
         // Unlike the @JavascriptInterface bridge, this method is always called on the UI thread.
         String handledRet = parentEngine.bridge.promptOnJsPrompt(origin, message, defaultValue);


### PR DESCRIPTION
Don't add the annotation of @Override before the function so that it will be compatible
with the crosswalk before the version of 17.
The commit in xwalk core library is
https://github.com/crosswalk-project/crosswalk/pull/3344#issuecomment-154415589