### PR TITLE
Set z order of web view with the preference ZOrderOnTop.

### DIFF
--- a/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
@@ -130,8 +130,8 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
     private void initWebViewSettings() {
         webView.setVerticalScrollBarEnabled(false);
 
-        if (preferences.contains("ZOrderOnTop")) {
-            boolean zOrderOnTop = preferences.getBoolean("ZOrderOnTop", true);
+        if (preferences.contains("xwalkZOrderOnTop")) {
+            boolean zOrderOnTop = preferences.getBoolean("xwalkZOrderOnTop", true);
             webView.setZOrderOnTop(zOrderOnTop);
         }
 

--- a/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
@@ -46,6 +46,7 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
 
     public static final String TAG = "XWalkWebViewEngine";
     public static final String XWALK_USER_AGENT = "xwalkUserAgent";
+    public static final String XWALK_Z_ORDER_ON_TOP = "xwalkZOrderOnTop";
 
     protected final XWalkCordovaView webView;
     protected XWalkCordovaCookieManager cookieManager;
@@ -130,10 +131,8 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
     private void initWebViewSettings() {
         webView.setVerticalScrollBarEnabled(false);
 
-        if (preferences.contains("xwalkZOrderOnTop")) {
-            boolean zOrderOnTop = preferences.getBoolean("xwalkZOrderOnTop", true);
-            webView.setZOrderOnTop(zOrderOnTop);
-        }
+        boolean zOrderOnTop = preferences == null ? false : preferences.getBoolean(XWALK_Z_ORDER_ON_TOP, false);
+        webView.setZOrderOnTop(zOrderOnTop);
 
         // Set xwalk webview settings by Cordova preferences.
         String xwalkUserAgent = preferences == null ? "" : preferences.getString(XWALK_USER_AGENT, "");

--- a/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
@@ -130,6 +130,11 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
     private void initWebViewSettings() {
         webView.setVerticalScrollBarEnabled(false);
 
+        if (preferences.contains("ZOrderOnTop")) {
+            boolean zOrderOnTop = preferences.getBoolean("ZOrderOnTop", true);
+            webView.setZOrderOnTop(zOrderOnTop);
+        }
+
         // Set xwalk webview settings by Cordova preferences.
         String xwalkUserAgent = preferences == null ? "" : preferences.getString(XWALK_USER_AGENT, "");
         if (!xwalkUserAgent.isEmpty()) {


### PR DESCRIPTION
Allow setting the web view zOrderOnTop from config.xml. 
This is useful when using this plugin together with plugins like https://github.com/mapsplugin/cordova-plugin-googlemaps which require the crosswalk web view to be drawn on top of them.