### PR TITLE
Don't touch the top-level config.xml.

### DIFF
--- a/hooks/update_config.js
+++ b/hooks/update_config.js
@@ -4,12 +4,12 @@ module.exports = function(context) {
 
     var ConfigParser, XmlHelpers;
     try {
-        ConfigParser = context.requireCordovaModule("cordova-lib/src/configparser/ConfigParser");
-        XmlHelpers = context.requireCordovaModule("cordova-lib/src/util/xml-helpers");
-    } catch (e) {
         // cordova-lib >= 5.3.4 doesn't contain ConfigParser and xml-helpers anymore
         ConfigParser = context.requireCordovaModule("cordova-common").ConfigParser;
         XmlHelpers = context.requireCordovaModule("cordova-common").xmlHelpers;
+    } catch (e) {
+        ConfigParser = context.requireCordovaModule("cordova-lib/src/configparser/ConfigParser");
+        XmlHelpers = context.requireCordovaModule("cordova-lib/src/util/xml-helpers");
     }
 
     /** @external */
@@ -108,21 +108,6 @@ module.exports = function(context) {
         if (xwalkVariables['xwalkMode'] == 'shared') {
             addPermission();
         }
-
-        // Configure the final value in the config.xml
-        var configXmlRoot = XmlHelpers.parseElementtreeSync(projectConfigurationFile);
-        var preferenceUpdated = false;
-        for (name in xwalkVariables) {
-            var child = configXmlRoot.find('./preference[@name="' + name + '"]');
-            if(!child) {
-                preferenceUpdated = true;
-                child = et.XML('<preference name="' + name + '" value="' + xwalkVariables[name] + '" />');
-                XmlHelpers.graftXML(configXmlRoot, [child], '/*');
-            }
-        }
-        if(preferenceUpdated) {
-            fs.writeFileSync(projectConfigurationFile, configXmlRoot.write({indent: 4}), 'utf-8');
-        }
     }
 
     /** Remove preference*/
@@ -131,15 +116,6 @@ module.exports = function(context) {
             // Add the permission of write_external_storage in shared mode
             removePermission();
         }
-
-        var configXmlRoot = XmlHelpers.parseElementtreeSync(projectConfigurationFile);
-        for (name in xwalkVariables) {
-            var child = configXmlRoot.find('./preference[@name="' + name + '"]');
-            if (child) {
-                XmlHelpers.pruneXML(configXmlRoot, [child], '/*');
-            }
-        }
-        fs.writeFileSync(projectConfigurationFile, configXmlRoot.write({indent: 4}), 'utf-8');
     }
 
     xwalkVariables = defaultPreferences();

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,14 +17,18 @@
         <engine name="cordova-plugman" version=">=4.2.0"/><!-- needed for gradleReference support -->
     </engines>
 
+    <preference name="XWALK_VERSION" default="15+" />
+    <preference name="XWALK_COMMANDLINE" default="--disable-pull-to-refresh-effect" />
+    <preference name="XWALK_MODE" default="embedded" />
+
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
             <preference name="webView" value="org.crosswalk.engine.XWalkWebViewEngine"/>
-            <preference name="xwalkVersion" default="15+"/>
-            <preference name="xwalkCommandLine" default="--disable-pull-to-refresh-effect"/>
-            <preference name="xwalkMode" default="embedded" />
-            <preference name="xwalkMultipleApk" default="true" />
+            <preference name="xwalkVersion" value="$XWALK_VERSION" />
+            <preference name="xwalkCommandLine" value="$XWALK_COMMANDLINE" />
+            <preference name="xwalkMode" value="$XWALK_MODE" />
+            <preference name="xwalkMultipleApk" value="true" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/*">


### PR DESCRIPTION
When installing this plugin, the top-level config.xml gets a bunch of preferences added and it causes the file to lose all comments and formatting, which has been a recurring complaint from developers on my team. Every time they make a build locally, they have to deal with undoing the config.xml clobbering from this plugin.

It isn't necessary to touch the top-level config at all, because those same variables are already being automatically added by plugin.xml to the platform-level config.xml.

Additionally, I changed the order of the try/catch requires so that it tries to use the 5.4.0-style first, rather than printing out a bunch of warning messages.