### PR TITLE
Support loading external extensions.

### DIFF
--- a/platforms/android/src/org/crosswalk/engine/XWalkCordovaView.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkCordovaView.java
@@ -7,15 +7,22 @@ import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.os.Bundle;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.KeyEvent;
 
+import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CordovaWebViewEngine;
 
 public class XWalkCordovaView extends XWalkView implements CordovaWebViewEngine.EngineView {
+
+    public static final String TAG = "XWalkCordovaView";
+
     protected XWalkCordovaResourceClient resourceClient;
     protected XWalkCordovaUiClient uiClient;
     protected XWalkWebViewEngine parentEngine;
@@ -78,6 +85,21 @@ public class XWalkCordovaView extends XWalkView implements CordovaWebViewEngine.
             this.uiClient = (XWalkCordovaUiClient)client;
         }
         super.setUIClient(client);
+    }
+
+    // Call CordovaInterface to start activity for result to make sure
+    // onActivityResult() callback will be triggered from CordovaActivity correctly.
+    // Todo(leonhsl) How to handle |options|?
+    @Override
+    public void startActivityForResult(Intent intent, int requestCode, Bundle options) {
+        parentEngine.cordova.startActivityForResult(new CordovaPlugin() {
+            @Override
+            public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+                // Route to XWalkView.
+                Log.i(TAG, "Route onActivityResult() to XWalkView");
+                XWalkCordovaView.this.onActivityResult(requestCode, resultCode, intent);
+            }
+        }, intent, requestCode);
     }
 
     @Override

--- a/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
@@ -21,8 +21,14 @@ package org.crosswalk.engine;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
+import android.content.res.AssetManager;
 import android.graphics.Color;
+import android.util.Log;
 import android.view.View;
+
+import java.io.File;
+import java.io.IOException;
 
 import org.apache.cordova.CordovaBridge;
 import org.apache.cordova.CordovaInterface;
@@ -47,6 +53,8 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
     public static final String TAG = "XWalkWebViewEngine";
     public static final String XWALK_USER_AGENT = "xwalkUserAgent";
     public static final String XWALK_Z_ORDER_ON_TOP = "xwalkZOrderOnTop";
+
+    private static final String XWALK_EXTENSIONS_FOLDER = "xwalk-extensions";
 
     protected final XWalkCordovaView webView;
     protected XWalkCordovaCookieManager cookieManager;
@@ -77,6 +85,16 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
 
                 initWebViewSettings();
                 exposeJsInterface(webView, bridge);
+                loadExtensions();
+
+                CordovaPlugin notifPlugin = new CordovaPlugin() {
+                    @Override
+                    public void onNewIntent(Intent intent) {
+                        Log.i(TAG, "notifPlugin route onNewIntent() to XWalkView: " + intent.toString());
+                        XWalkWebViewEngine.this.webView.onNewIntent(intent);
+                    }
+                };
+                pluginManager.addService(new PluginEntry("XWalkNotif", notifPlugin));
 
                 loadUrl(startUrl, true);
             }
@@ -148,6 +166,24 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
     private static void exposeJsInterface(XWalkView webView, CordovaBridge bridge) {
         XWalkExposedJsApi exposedJsApi = new XWalkExposedJsApi(bridge);
         webView.addJavascriptInterface(exposedJsApi, "_cordovaNative");
+    }
+
+    private void loadExtensions() {
+        AssetManager assetManager = cordova.getActivity().getAssets();
+        String[] extList;
+        try {
+            Log.i(TAG, "Iterate assets/xwalk-extensions folder");
+            extList = assetManager.list(XWALK_EXTENSIONS_FOLDER);
+        } catch (IOException e) {
+            Log.w(TAG, "Failed to iterate assets/xwalk-extensions folder");
+            return;
+        }
+
+        for (String path : extList) {
+            // Load the extension.
+            Log.i(TAG, "Start to load extension: " + path);
+            webView.getExtensionManager().loadExtension(XWALK_EXTENSIONS_FOLDER + File.separator + path);
+        }
     }
 
     @Override


### PR DESCRIPTION
Load all extension sub-folders under assets/xwalk-extensions.
Employ Cordova plugin to enforce XWalkView get onNewIntent() and
onActivityResult() callback.

BUG=XWALK-5757