### PR TITLE
Send the message of xwalk's ready to plugin

### DIFF
--- a/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
@@ -79,6 +79,10 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
                 exposeJsInterface(webView, bridge);
 
                 loadUrl(startUrl, true);
+                // Send the massage of xwalk's ready to plugin.
+                if (pluginManager != null) {
+                    pluginManager.postMessage("onXWalkReady", this);
+                }
             }
         };
         activityDelegate = new XWalkActivityDelegate((Activity) context, cancelCommand, completeCommand);


### PR DESCRIPTION
Customer can listen the callback of onMessage in CordovaPlugin, also can
add plugin service to receive the message in CordovaActivity.