### PR TITLE
[iOS] Enabled XWalkView within Cordova Crosswalk Plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "cordova-ios",
-      "version": ">=3.9.2"
+      "version": ">=4"
     },
     {
       "name": "cordova-plugman",

--- a/platforms/ios/src/XWalkNavigationDelegate.h
+++ b/platforms/ios/src/XWalkNavigationDelegate.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a Apache V2.0 license that can be
+// found in the LICENSE file.
+
+#import <WebKit/WebKit.h>
+
+@class XWalkWebViewEngine;
+
+@interface XWalkNavigationDelegate : NSObject <WKNavigationDelegate>
+
+- (id)initWithWebViewEngine:(XWalkWebViewEngine*)engine;
+
+@end

--- a/platforms/ios/src/XWalkNavigationDelegate.m
+++ b/platforms/ios/src/XWalkNavigationDelegate.m
@@ -1,0 +1,132 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a Apache V2.0 license that can be
+// found in the LICENSE file.
+
+#import "XWalkNavigationDelegate.h"
+
+#import <Cordova/CDVViewController.h>
+#import <Cordova/CDVUserAgentUtil.h>
+#import <objc/message.h>
+#import "XWalkWebViewEngine.h"
+
+@interface XWalkNavigationDelegate ()
+
+@property(nonatomic, weak) XWalkWebViewEngine* engine;
+
+@end
+
+@implementation XWalkNavigationDelegate
+
+- (id)initWithWebViewEngine:(XWalkWebViewEngine*)engine {
+    if (self = [super init]) {
+        _engine = engine;
+    }
+    return self;
+}
+
+- (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation {
+    NSLog(@"Resetting plugins due to page load.");
+    CDVViewController* controller = (CDVViewController*)self.engine.viewController;
+
+    [controller.commandQueue resetRequestId];
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginResetNotification object:webView]];
+}
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    NSLog(@"Finished load of: %@", webView.URL);
+    CDVViewController* controller = (CDVViewController*)self.engine.viewController;
+
+    // It's safe to release the lock even if this is just a sub-frame that's finished loading.
+    [CDVUserAgentUtil releaseLock:controller.userAgentLockToken];
+
+    /*
+     * Hide the Top Activity THROBBER in the Battery Bar
+     */
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPageDidLoadNotification object:webView]];
+}
+
+- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    [self webView:webView failedNavigation:navigation withError:error];
+}
+
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    [self webView:webView failedNavigation:navigation withError:error];
+}
+
+- (void)webView:(WKWebView *)webView failedNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    CDVViewController* controller = (CDVViewController*)self.engine.viewController;
+
+    [CDVUserAgentUtil releaseLock:controller.userAgentLockToken];
+
+    NSString* message = [NSString stringWithFormat:@"Failed to load webpage with error: %@", [error localizedDescription]];
+    NSLog(@"%@", message);
+
+    NSURL* errorUrl = controller.errorURL;
+    if (errorUrl) {
+        errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] relativeToURL:errorUrl];
+        NSLog(@"%@", [errorUrl absoluteString]);
+        [webView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
+    }
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+    NSURL* url = navigationAction.request.URL;
+    CDVViewController* controller = (CDVViewController*)self.engine.viewController;
+
+    if ([url.scheme isEqualToString:@"gap"]) {
+        [controller.commandQueue fetchCommandsFromJs];
+        [controller.commandQueue executePending];
+        decisionHandler(WKNavigationActionPolicyCancel);
+        return;
+    }
+
+    /*
+     * Give plugins the chance to handle the url
+     */
+    BOOL anyPluginsResponded = NO;
+    BOOL shouldAllowRequest = NO;
+
+    for (NSString* pluginName in controller.pluginObjects) {
+        CDVPlugin* plugin = [controller.pluginObjects objectForKey:pluginName];
+        SEL selector = NSSelectorFromString(@"shouldOverrideLoadWithRequest:navigationType:");
+        if ([plugin respondsToSelector:selector]) {
+            anyPluginsResponded = YES;
+            shouldAllowRequest = (((BOOL (*)(id, SEL, id, int))objc_msgSend)(plugin, selector, navigationAction.request, navigationAction.navigationType));
+            if (!shouldAllowRequest) {
+                break;
+            }
+        }
+    }
+
+    if (anyPluginsResponded) {
+        decisionHandler(shouldAllowRequest ? WKNavigationActionPolicyAllow : WKNavigationActionPolicyCancel);
+        return;
+    }
+
+    /*
+     * Handle all other types of urls (tel:, sms:), and requests to load a url in the main webview.
+     */
+    BOOL shouldAllowNavigation = [self defaultResourcePolicyForURL:url];
+    if (shouldAllowNavigation) {
+        decisionHandler(WKNavigationActionPolicyAllow);
+        return;
+    }
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
+    decisionHandler(WKNavigationActionPolicyCancel);
+}
+
+- (BOOL)defaultResourcePolicyForURL:(NSURL*)url
+{
+    /*
+     * If a URL is being loaded that's a file url, just load it internally
+     */
+    if ([url isFileURL]) {
+        return YES;
+    }
+
+    return NO;
+}
+
+@end

--- a/platforms/ios/src/XWalkUIDelegate.h
+++ b/platforms/ios/src/XWalkUIDelegate.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a Apache V2.0 license that can be
+// found in the LICENSE file.
+
+#import <WebKit/WebKit.h>
+
+@class XWalkWebViewEngine;
+
+@interface XWalkUIDelegate : NSObject <WKUIDelegate>
+
+- (id)initWithEngine:(XWalkWebViewEngine*)engine;
+
+@end

--- a/platforms/ios/src/XWalkUIDelegate.m
+++ b/platforms/ios/src/XWalkUIDelegate.m
@@ -1,0 +1,24 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a Apache V2.0 license that can be
+// found in the LICENSE file.
+
+#import "XWalkUIDelegate.h"
+
+#import "XWalkWebViewEngine.h"
+
+@interface XWalkUIDelegate ()
+
+@property(nonatomic, weak) XWalkWebViewEngine* engine;
+
+@end
+
+@implementation XWalkUIDelegate
+
+- (id)initWithEngine:(XWalkWebViewEngine*)engine {
+    if (self = [super init]) {
+        _engine = engine;
+    }
+    return self;
+}
+
+@end

--- a/platforms/ios/src/XWalkWebViewEngine.h
+++ b/platforms/ios/src/XWalkWebViewEngine.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a Apache V2.0 license that can be
+// found in the LICENSE file.
+
+#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVWebViewEngineProtocol.h>
+#import <WebKit/WebKit.h>
+
+@interface XWalkWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol>
+
+@property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
+@property (nonatomic, strong, readonly) id <WKNavigationDelegate> navigationDelegate;
+
+@end

--- a/platforms/ios/src/XWalkWebViewEngine.m
+++ b/platforms/ios/src/XWalkWebViewEngine.m
@@ -1,0 +1,79 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a Apache V2.0 license that can be
+// found in the LICENSE file.
+
+#import "XWalkWebViewEngine.h"
+
+#import <Cordova/NSDictionary+CordovaPreferences.h>
+#import <XWalkView/XWalkView.h>
+#import "XWalkNavigationDelegate.h"
+#import "XWalkUIDelegate.h"
+
+@interface XWalkWebViewEngine ()
+
+@property (nonatomic, strong, readwrite) XWalkView* engineWebView;
+@property (nonatomic, strong, readwrite) id <WKUIDelegate> uiDelegate;
+@property (nonatomic, strong, readwrite) id <WKNavigationDelegate> navigationDelegate;
+
+@end
+
+@implementation XWalkWebViewEngine
+
+@synthesize engineWebView;
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super init]) {
+        self.engineWebView = [[XWalkView alloc] initWithFrame:frame];
+        NSLog(@"Using XWalkView");
+    }
+    return self;
+}
+
+- (void)pluginInitialize {
+    self.uiDelegate = [[XWalkUIDelegate alloc] initWithEngine:self];
+    [self.engineWebView setUIDelegate:self.uiDelegate];
+    self.navigationDelegate = [[XWalkNavigationDelegate alloc] initWithWebViewEngine:self];
+    [self.engineWebView setNavigationDelegate:self.navigationDelegate];
+    [self updateSettings:self.commandDelegate.settings];
+}
+
+- (void)updateSettings:(NSDictionary*)settings {
+    BOOL bounceAllowed = !([settings cordovaBoolSettingForKey:@"DisallowOverscroll" defaultValue:NO]);
+    if (!bounceAllowed) {
+        self.engineWebView.scrollView.bounces = NO;
+    }
+
+    NSString* decelerationSetting = [settings cordovaSettingForKey:@"UIWebViewDecelerationSpeed"];
+    if (![@"fast" isEqualToString:decelerationSetting]) {
+        [self.engineWebView.scrollView setDecelerationRate:UIScrollViewDecelerationRateNormal];
+    }
+}
+
+- (id)loadRequest:(NSURLRequest*)request {
+    return [self.engineWebView loadRequest:request];
+}
+
+- (id)loadHTMLString:(NSString*)string baseURL:(NSURL*)baseURL {
+    return [self.engineWebView loadHTMLString:string baseURL:baseURL];
+}
+
+- (void)evaluateJavaScript:(NSString*)javaScriptString completionHandler:(void (^)(id, NSError*))completionHandler {
+    [self.engineWebView evaluateJavaScript:javaScriptString completionHandler:completionHandler];
+}
+
+- (NSURL*)URL {
+    return self.engineWebView.URL;
+}
+
+- (BOOL)canLoadRequest:(NSURLRequest*)request {
+    return request != nil;
+}
+
+- (void)updateWithInfo:(NSDictionary*)info {
+    NSDictionary* settings = [info objectForKey:kCDVWebViewEngineWebViewPreferences];
+    if (settings && [settings isKindOfClass:[NSDictionary class]]) {
+        [self updateSettings:settings];
+    }
+}
+
+@end

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     <engines>
         <engine name="cordova-android" version=">=4"/>
         <engine name="cordova-plugman" version=">=4.2.0"/><!-- needed for gradleReference support -->
-        <engine name="cordova-ios" version=">=3.9.2"/>
+        <engine name="cordova-ios" version=">=4.0.1"/>
     </engines>
 
     <!-- android -->
@@ -52,8 +52,18 @@
 
     <!-- iOS -->
     <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <preference name="CordovaWebViewEngine" value="XWalkWebViewEngine"/>
+        </config-file>
         <framework src="platforms/ios/frameworks/GCDWebServer.framework" custom="true"/>
         <framework src="platforms/ios/frameworks/XWalkView.framework" custom="true"/>
+
+        <header-file src="platforms/ios/src/XWalkNavigationDelegate.h"/>
+        <source-file src="platforms/ios/src/XWalkNavigationDelegate.m"/>
+        <header-file src="platforms/ios/src/XWalkUIDelegate.h"/>
+        <source-file src="platforms/ios/src/XWalkUIDelegate.m"/>
+        <header-file src="platforms/ios/src/XWalkWebViewEngine.h"/>
+        <source-file src="platforms/ios/src/XWalkWebViewEngine.m"/>
 
         <hook type="after_plugin_install" src="hooks/ios/after_plugin_install/000-update_xcode_config.js"/>
         <hook type="before_plugin_uninstall" src="hooks/ios/before_plugin_uninstall/000-remove_xcode_config.js"/>


### PR DESCRIPTION
As cordova-cli upgraded to v6.0.0 and cordova-ios upgraded to v4.0.1,
a new interface for web engine has been introduced, which makes it
easier to embed a WKWebView based third party WebView. Our
implementation is based on this new interface. Within this patch we've
Created a new XWalkWebViewEngine which wraps the XWalkView as its
webview, and implemented the required delegates.

BUG=XWALK-4911