### PR TITLE
Add missing vars to fix ReferenceErrors in Node v4

### DIFF
--- a/hooks/update_config.js
+++ b/hooks/update_config.js
@@ -75,7 +75,7 @@ module.exports = function(context) {
     /** The style of name align with config.xml */
     var setConfigPreference = function(name, value) {
         var trimName = name.replace('_', '');
-        for (localName in xwalkVariables) {
+        for (var localName in xwalkVariables) {
             if (localName.toUpperCase() == trimName.toUpperCase()) {
                 xwalkVariables[localName] = value;
             }
@@ -111,7 +111,7 @@ module.exports = function(context) {
         // Configure the final value in the config.xml
         var configXmlRoot = XmlHelpers.parseElementtreeSync(projectConfigurationFile);
         var preferenceUpdated = false;
-        for (name in xwalkVariables) {
+        for (var name in xwalkVariables) {
             var child = configXmlRoot.find('./preference[@name="' + name + '"]');
             if(!child) {
                 preferenceUpdated = true;
@@ -132,7 +132,7 @@ module.exports = function(context) {
         }
 
         var configXmlRoot = XmlHelpers.parseElementtreeSync(projectConfigurationFile);
-        for (name in xwalkVariables) {
+        for (var name in xwalkVariables) {
             var child = configXmlRoot.find('./preference[@name="' + name + '"]');
             if (child) {
                 XmlHelpers.pruneXML(configXmlRoot, [child], '/*');


### PR DESCRIPTION
To fix the error I was getting with the cordova create:

```
ReferenceError: name is not defined
    at [object Object].addPreferences (update_config.js:116:13)
    at main (000-shared_mode_special.js:11:27)
    at module.exports (000-shared_mode_special.js:3:36)

```
