### PR TITLE
Fixes exception thrown when cdvBuildMultipleApks is set via the command line options

### DIFF
--- a/platforms/android/xwalk.gradle
+++ b/platforms/android/xwalk.gradle
@@ -52,6 +52,8 @@ if (!project.hasProperty('xwalk64bit')) {
 }
 if (cdvBuildMultipleApks == null) {
     ext.xwalkMultipleApk = getConfigPreference("xwalkMultipleApk").toBoolean();
+} else {
+    ext.xwalkMultipleApk = cdvBuildMultipleApks.toBoolean();
 }
 
 if (cdvMinSdkVersion == null) {


### PR DESCRIPTION
Run the following command to reproduce the error:

```
cordova build android -- --gradleArg=-PcdvBuildMultipleApks=false
```

It doen't matter if `cdvBuildMultipleApks` is set to `true` or `false`.

Following error is thrown:

```
Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.
java.lang.IllegalStateException: buildToolsVersion is not specified.
	at com.google.common.base.Preconditions.checkState(Preconditions.java:176)
	at com.android.build.gradle.BasePlugin.createAndroidTasks(BasePlugin.java:599)
	at com.android.build.gradle.BasePlugin$10$1.call(BasePlugin.java:566)
	at com.android.build.gradle.BasePlugin$10$1.call(BasePlugin.java:563)
	at com.android.builder.profile.ThreadRecorder$1.record(ThreadRecorder.java:55)
	at com.android.builder.profile.ThreadRecorder$1.record(ThreadRecorder.java:47)
	at com.android.build.gradle.BasePlugin$10.execute(BasePlugin.java:562)
	at com.android.build.gradle.BasePlugin$10.execute(BasePlugin.java:559)
	at org.gradle.listener.BroadcastDispatch$ActionInvocationHandler.dispatch(BroadcastDispatch.java:109)
	at org.gradle.listener.BroadcastDispatch$ActionInvocationHandler.dispatch(BroadcastDispatch.java:98)
	at org.gradle.listener.BroadcastDispatch.dispatch(BroadcastDispatch.java:83)
	at org.gradle.listener.BroadcastDispatch.dispatch(BroadcastDispatch.java:31)
	at org.gradle.messaging.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
	at com.sun.proxy.$Proxy12.afterEvaluate(Unknown Source)
	at org.gradle.configuration.project.LifecycleProjectEvaluator.notifyAfterEvaluate(LifecycleProjectEvaluator.java:79)
	at org.gradle.configuration.project.LifecycleProjectEvaluator.evaluate(LifecycleProjectEvaluator.java:65)
	at org.gradle.api.internal.project.AbstractProject.evaluate(AbstractProject.java:504)
	at org.gradle.api.internal.project.AbstractProject.evaluate(AbstractProject.java:83)
	at org.gradle.execution.TaskPathProjectEvaluator.configureHierarchy(TaskPathProjectEvaluator.java:42)
	at org.gradle.configuration.DefaultBuildConfigurer.configure(DefaultBuildConfigurer.java:35)
	at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:129)
	at org.gradle.initialization.DefaultGradleLauncher.doBuild(DefaultGradleLauncher.java:106)
	at org.gradle.initialization.DefaultGradleLauncher.run(DefaultGradleLauncher.java:86)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter$DefaultBuildController.run(InProcessBuildActionExecuter.java:80)
	at org.gradle.launcher.cli.ExecuteBuildAction.run(ExecuteBuildAction.java:33)
	at org.gradle.launcher.cli.ExecuteBuildAction.run(ExecuteBuildAction.java:24)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:36)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:26)
	at org.gradle.launcher.daemon.server.exec.ExecuteBuild.doBuild(ExecuteBuild.java:47)
	at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:34)
	at org.gradle.launcher.daemon.server.exec.DaemonCommandExecution.proceed(DaemonCommandExecution.java:119)
	at org.gradle.launcher.daemon.server.exec.WatchForDisconnection.execute(WatchForDisconnection.java:35)
	at org.gradle.launcher.daemon.server.exec.DaemonCommandExecution.proceed(DaemonCommandExecution.java:119)
	at org.gradle.launcher.daemon.server.exec.ResetDeprecationLogger.execute(ResetDeprecationLogger.java:24)
	at org.gradle.launcher.daemon.server.exec.DaemonCommandExecution.proceed(DaemonCommandExecution.java:119)
	at org.gradle.launcher.daemon.server.exec.StartStopIfBuildAndStop.execute(StartStopIfBuildAndStop.java:33)
	at org.gradle.launcher.daemon.server.exec.DaemonCommandExecution.proceed(DaemonCommandExecution.java:119)
	at org.gradle.launcher.daemon.server.exec.ForwardClientInput$2.call(ForwardClientInput.java:71)
	at org.gradle.launcher.daemon.server.exec.ForwardClientInput$2.call(ForwardClientInput.java:69)
	at org.gradle.util.Swapper.swap(Swapper.java:38)
	at org.gradle.launcher.daemon.server.exec.ForwardClientInput.execute(ForwardClientInput.java:69)
	at org.gradle.launcher.daemon.server.exec.DaemonCommandExecution.proceed(DaemonCommandExecution.java:119)
	at org.gradle.launcher.daemon.server.exec.LogToClient.doBuild(LogToClient.java:60)
	at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:34)
	at org.gradle.launcher.daemon.server.exec.DaemonCommandExecution.proceed(DaemonCommandExecution.java:119)
	at org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment.doBuild(EstablishBuildEnvironment.java:70)
	at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:34)
	at org.gradle.launcher.daemon.server.exec.DaemonCommandExecution.proceed(DaemonCommandExecution.java:119)
	at org.gradle.launcher.daemon.server.exec.DaemonHygieneAction.execute(DaemonHygieneAction.java:39)
	at org.gradle.launcher.daemon.server.exec.DaemonCommandExecution.proceed(DaemonCommandExecution.java:119)
	at org.gradle.launcher.daemon.server.exec.StartBuildOrRespondWithBusy$1.run(StartBuildOrRespondWithBusy.java:46)
	at org.gradle.launcher.daemon.server.DaemonStateCoordinator$1.run(DaemonStateCoordinator.java:246)
	at org.gradle.internal.concurrent.DefaultExecutorFactory$StoppableExecutorImpl$1.run(DefaultExecutorFactory.java:64)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:744)

FAILURE: Build failed with an exception.

* Where:
Script '/xxx/platforms/android/cordova-plugin-crosswalk-webview/android-xwalk.gradle' line: 73

* What went wrong:
A problem occurred evaluating script.
> Could not find property 'xwalkMultipleApk' on root project 'android'.
```

This fix makes sure that `ext.xwalkMultipleApk` is set even `cdvBuildMultipleApks` is set via a command line parameter.