### PR TITLE
Implement evaluateJavascript method for Cordova 6

### DIFF
--- a/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
@@ -27,6 +27,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.util.Log;
 import android.view.View;
+import android.webkit.ValueCallback;
 
 import java.io.File;
 import java.io.IOException;
@@ -300,6 +301,16 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
             return;
         }
         webView.load(url, null);
+    }
+
+    /**
+     * This API is used in Cordova-Android 6.0.0 override from
+     *
+     * CordovaWebViewEngine.java
+     * @since Cordova 6.0
+     */
+    public void evaluateJavascript(String js, ValueCallback<String> callback) {
+        webView.evaluateJavascript(js, callback);
     }
 
     public boolean isXWalkReady() {


### PR DESCRIPTION
Required for Cordova-Android v6 compatibility with the new (threadsafe) bridge method: https://github.com/apache/cordova-android/pull/320