### PR TITLE
Add `cordovaDependencies` section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,21 @@
     "ecosystem:cordova",
     "cordova-android"
   ],
-  "engines": [
-    {
-      "name": "cordova-android",
-      "version": ">=4"
-    },
-    {
-      "name": "cordova-plugman",
-      "version": ">=4.2.0"
+  "engines": {
+    "cordovaDependencies": {
+      "2.0.0": {
+        "cordova": ">=5.2.0",
+        "cordova-android": "4 - 5"
+      },
+      "2.1.0": {
+        "cordova": ">=5.2.0",
+        "cordova-android": ">=4"
+      },
+      "3.0.0": {
+        "cordova": ">100"
+      }
     }
-  ],
+  },
   "author": "",
   "license": "Apache 2.0",
   "bugs": {


### PR DESCRIPTION
This PR has the following purposes:

- reflect `engines` elements from plugin manifest to package.json to comply w/ [new plugin fetching model](https://github.com/cordova/cordova-discuss/blob/master/proposals/plugin-version-fetching.md).
- add compatibility entry for cordova-android 6.0.0 (as per #95  and #97)
- add 'protective' entry for next major plugin version to protect end-users from fetching edge versions of the plugin by incompatible version of cordova. See corresponding [discussion on mailing list](http://apache.markmail.org/thread/p73loqtvbzvfzsv5) for more details and reasons behind this.