### PR TITLE
Add the JSEval bridge mode

### DIFF
--- a/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
@@ -174,6 +174,7 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
                 XWalkWebViewEngine.this.cordova.getActivity().runOnUiThread(r);
             }
         }));
+        nativeToJsMessageQueue.addBridgeMode(new NativeToJsMessageQueue.EvalBridgeMode(this, cordova));
         bridge = new CordovaBridge(pluginManager, nativeToJsMessageQueue);
     }
 


### PR DESCRIPTION
This allows Crosswalk to use the evaluateJavascript bridge.

Background Info: https://lists.apache.org/thread.html/e886806222f00276e45e06fe549a4d37aff5563a5f760a8f4f10e8b0@%3Cdev.cordova.apache.org%3E