### PR TITLE
Update cordova-android dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,11 @@
       },
       "2.1.0": {
         "cordova": ">=5.2.0",
-        "cordova-android": ">=4"
+        "cordova-android": "4 - 5"
+      },
+      "2.2.0": {
+        "cordova": ">=5.2.0",
+        "cordova-android": ">=6"
       },
       "3.0.0": {
         "cordova": ">100"

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,7 @@
     <issue>https://crosswalk-project.org/jira</issue>
 
     <engines>
-        <engine name="cordova-android" version=">=4"/>
+        <engine name="cordova-android" version=">=6"/>
         <engine name="cordova-plugman" version=">=5.2.0"/><!-- needed for gradleReference support -->
     </engines>
 


### PR DESCRIPTION
Hey guys,

Due to some recent changes (https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview/pull/100) crosswalk cannot be built for cordova-android@<6 anymore

To address that, engine versions should be updated in plugin.xml as well as in package.json

**Important**: Please note that my changes in package.json are assuming that next crosswalk version is 2.2.0
If that's not true, it should be updated to a correct version number upon release.