### PR TITLE
Override cdvMinSdkVersion if it's lower than needed

### DIFF
--- a/platforms/android/xwalk.gradle
+++ b/platforms/android/xwalk.gradle
@@ -25,6 +25,7 @@ def SHARED_ARTIFACT_ID = "xwalk_shared_library:"
 def EMBEDD_ARTIFACT_ID = "xwalk_core_library:"
 def CANARY_ARTIFACT_ID = "xwalk_core_library_canary:"
 def BIT_64 = ":64bit@aar"
+def DEFAULT_MIN_SDK_VERSION = 14
 
 def getConfigPreference(name) {
     name = name.toLowerCase()
@@ -56,9 +57,11 @@ if (cdvBuildMultipleApks == null) {
     ext.xwalkMultipleApk = cdvBuildMultipleApks.toBoolean();
 }
 
+def minSdk = getConfigPreference("android-minSdkVersion");
 if (cdvMinSdkVersion == null) {
-    def minSdk = getConfigPreference("android-minSdkVersion");
-    ext.cdvMinSdkVersion =  minSdk && minSdk.toInteger() > 14 ? minSdk : 14;
+    ext.cdvMinSdkVersion = minSdk && Integer.parseInt(minSdk) > DEFAULT_MIN_SDK_VERSION ? minSdk : DEFAULT_MIN_SDK_VERSION;
+} else if (cdvMinSdkVersion < Integer.parseInt(minSdk)) {
+    ext.cdvMinSdkVersion = minSdk;
 }
 
 if (!project.hasProperty('xwalkMode')) {


### PR DESCRIPTION
This is a fix for https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/337

Repro (cordova@6.4.0):
```
cordova create crosswalk-problem
cd crosswalk-problem
cordova platform add android
cordova plugin add https://github.com/phonegap/phonegap-plugin-barcodescanner
cordova plugin add https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview
cordova compile
```