### PR TITLE
update_config.js: Do not hardcode path separator.

### DIFF
--- a/hooks/update_config.js
+++ b/hooks/update_config.js
@@ -32,12 +32,15 @@ module.exports = function(context) {
         xwalkLiteVersion = "",
         specificVersion = false;
 
-    if (fs.existsSync(androidPlatformDir + 'app/src/main/res/xml/config.xml')) {
+    var oldConfigXMLLocation = path.join(androidPlatformDir, 'res', 'xml', 'config.xml');
+    var newConfigXMLLocation = path.join(androidPlatformDir, 'app', 'src', 'main', 'res', 'xml', 'config.xml');
+
+    if (fs.existsSync(newConfigXMLLocation)) {
         // cordova-android >= 7.0.0
-        platformConfigurationFile = path.join(androidPlatformDir, 'app', 'src', 'main', 'res', 'xml', 'config.xml');
+        platformConfigurationFile = newConfigXMLLocation;
     } else {
         // cordova-android < 7.0.0
-        platformConfigurationFile = path.join(androidPlatformDir, 'res', 'xml', 'config.xml');
+        platformConfigurationFile = oldConfigXMLLocation;
     }
 
     /** Init */


### PR DESCRIPTION
Follow-up to e581761 ("fixed compatibility issues with
cordova-android@7.0.0"). Further comments in #188 indicate that hardcoding
'/' as the path separator when calling fs.existsSync() does not work well on
Windows.

Use path.join() everywhere as suggested by @nbinand.