### PR TITLE
Changes deprecated compile to implementation

### DIFF
--- a/platforms/android/xwalk.gradle
+++ b/platforms/android/xwalk.gradle
@@ -158,7 +158,7 @@ cdvPluginPostBuildExtras.add({
     println xwalkSpec
 
     dependencies {
-        compile xwalkSpec
+        implementation xwalkSpec
     }
 
     if (file('assets/xwalk-command-line').exists()) {


### PR DESCRIPTION
Since gradle 3.0 the compile option is deprecated. They request us to use implementation instead.
More info: https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html