### PR TITLE
Fix gradle throwing error on xwalk64bit preference

### DIFF
--- a/platforms/android/xwalk.gradle
+++ b/platforms/android/xwalk.gradle
@@ -115,6 +115,7 @@ cdvPluginPostBuildExtras.add({
 
     android {
         if (xwalk64bit != null) {
+            flavorDimensions "default"
             productFlavors {
                 x86_64 {
                     versionCode defaultConfig.versionCode + 6


### PR DESCRIPTION
Fixes `"All flavors must now belong to a named flavor dimension"` error